### PR TITLE
MWPW-174955: remove renew and banner functionality, spp, tpp from codebase

### DIFF
--- a/eds/scripts/personalization.js
+++ b/eds/scripts/personalization.js
@@ -1,7 +1,6 @@
 import {
   isMember,
   getNodesByXPath,
-  isRenew,
   getPartnerDataCookieObject, isSPPOnly, isTPPOnly, isSPPandTPP
 } from './utils.js';
 import { getConfig } from '../blocks/utils/utils.js';
@@ -104,23 +103,6 @@ export function applyPagePersonalization() {
   personalizePage(main);
 }
 
-function processRenew(profile) {
-  if(!profile){
-    return;
-  }
-  const { env } = getConfig();
-  const renew = isRenew();
-  const renewElements = Array.from(profile.querySelectorAll('.partner-renew'));
-  renewElements.forEach((el) => {
-    el.classList.add(PERSONALIZATION_HIDE);
-    if (!renew) return;
-    const { accountStatus } = renew;
-    if (el.classList.contains(`partner-${accountStatus}`)) {
-      el.classList.remove(PERSONALIZATION_HIDE);
-    }
-  });
-}
-
 function processGnavElements(elements) {
   const regex = /\((.*?)\)/g;
   return elements.map((el) => {
@@ -217,7 +199,6 @@ function personalizeProfile(gnav) {
   }
 
   personalizeDropdownElements(profile);
-  processRenew(profile);
 }
 
 export function applyGnavPersonalization(gnav) {

--- a/eds/scripts/personalizationUtils.js
+++ b/eds/scripts/personalizationUtils.js
@@ -1,11 +1,11 @@
-import { getPartnerDataCookieObject, hasSalesCenterAccess } from './utils.js';
+import { getPartnerDataCookieObject, getPartnerDataCookieValue, hasSalesCenterAccess } from './utils.js';
 import { PROGRAM } from '../blocks/utils/dxConstants.js';
 
 export const PERSONALIZATION_HIDE = 'personalization-hide';
 export const COOKIE_OBJECT = getPartnerDataCookieObject(PROGRAM);
 
 export function processPrimaryContact(el) {
-  const isPrimary = COOKIE_OBJECT.primaryContact;
+  const isPrimary = getPartnerDataCookieValue('primarycontact');
   el.classList.add(PERSONALIZATION_HIDE);
   if (!isPrimary) return;
   const primaryContactWrapper = document.createElement('div');

--- a/eds/scripts/scripts.js
+++ b/eds/scripts/scripts.js
@@ -16,7 +16,7 @@ import {
   preloadResources,
   redirectLoggedinPartner,
   updateNavigation,
-  updateFooter, updateIMSConfig, getRenewBanner, PARTNER_LOGIN_QUERY,
+  updateFooter, updateIMSConfig, PARTNER_LOGIN_QUERY,
 } from './utils.js';
 import { applyPagePersonalization } from './personalization.js';
 import { rewriteLinks } from './rewriteLinks.js';
@@ -102,7 +102,6 @@ async function loadPage() {
   const { loadArea, setConfig, getConfig } = await import(`${miloLibs}/utils/utils.js`);
 
   setConfig({ ...CONFIG, miloLibs });
-  await getRenewBanner(getConfig);
   await loadArea();
   applyPagePersonalization();
   rewriteLinks(document);

--- a/test/scripts/mocks/head.html
+++ b/test/scripts/mocks/head.html
@@ -2,7 +2,7 @@
   <meta name="footer" content="global-footer">
   <meta name="header" content="global-navigation">
   <meta name="jarvis-chat" content="on">
-  <meta name="adobe-target-after-logout" content="/solutionpartners/">
+  <meta name="adobe-target-after-logout" content="/digitalexperience/">
   <meta name="gnav-source" content="/eds/partners-shared/dx-gnav">
   <meta name="footer-source" content="/eds/partners-shared/dx-footer">
   <meta name="gnav-loggedin-source" content="/eds/partners-shared/dx-loggedin-gnav">

--- a/test/scripts/personalization.jest.js
+++ b/test/scripts/personalization.jest.js
@@ -20,7 +20,7 @@ describe('Test personalization.js', () => {
     window = Object.create(window);
     Object.defineProperties(window, {
       location: {
-        value: { pathname: '/solutionpartners/', hostname: 'partners.adobe.com' },
+        value: { pathname: '/digitalexperience/', hostname: 'partners.adobe.com' },
         writable: true,
       },
     });
@@ -247,58 +247,16 @@ describe('Test personalization.js', () => {
           SPP: {
             status: 'MEMBER',
             firstName: 'Test Name',
-            level: 'Platinum',
             company: 'Test Company',
-            primaryContact: true,
           },
+          level: 'Platinum',
+          primaryContact: true,
         };
         document.cookie = `partner_data=${JSON.stringify(cookieObject)}`;
         const { applyGnavPersonalization } = importModules();
         const personalizedGnav = applyGnavPersonalization(gnav);
         const primaryContact = personalizedGnav.querySelector('.primary-contact-wrapper');
         expect(primaryContact).toBeTruthy();
-      });
-    });
-    it('Show renew expired', () => {
-      jest.isolateModules(() => {
-        const expiredDate = new Date();
-        expiredDate.setDate(expiredDate.getDate() + 30);
-        const cookieObject = {
-          SPP: {
-            status: 'MEMBER',
-            firstName: 'Test Name',
-            company: 'Test Company',
-            accountAnniversary: expiredDate
-          },
-          level: 'Gold',
-          primaryContact: true
-        };
-        document.cookie = `partner_data=${JSON.stringify(cookieObject)}`;
-        const { applyGnavPersonalization } = importModules();
-        const personalizedGnav = applyGnavPersonalization(gnav);
-        const renewExpired = personalizedGnav.querySelector('.partner-expired');
-        expect(renewExpired.classList.contains(PERSONALIZATION_HIDE_CLASS)).toBeFalsy();
-      });
-    });
-    it('Show renew suspended', () => {
-      jest.isolateModules(() => {
-        const expiredDate = new Date();
-        expiredDate.setDate(expiredDate.getDate() - 30);
-        const cookieObject = {
-          SPP: {
-            status: 'MEMBER',
-            firstName: 'Test Name',
-            company: 'Test Company',
-            accountAnniversary: expiredDate
-          },
-          level: 'Gold',
-          primaryContact: true
-        };
-        document.cookie = `partner_data=${JSON.stringify(cookieObject)}`;
-        const { applyGnavPersonalization } = importModules();
-        const personalizedGnav = applyGnavPersonalization(gnav);
-        const renewExpired = personalizedGnav.querySelector('.partner-suspended');
-        expect(renewExpired.classList.contains(PERSONALIZATION_HIDE_CLASS)).toBeFalsy();
       });
     });
 
@@ -308,11 +266,11 @@ describe('Test personalization.js', () => {
           SPP: {
             status: 'MEMBER',
             firstName: 'Test Name',
-            level: 'Gold',
             company: 'Test Company',
-            primaryContact: true,
-            salesCenterAccess: true,
           },
+          level: 'Gold',
+          primaryContact: true,
+          salesCenterAccess: true,
         };
         document.cookie = `partner_data=${JSON.stringify(cookieObject)}`;
         const salesCenterLink = gnav.querySelector('#sales-link');
@@ -327,11 +285,11 @@ describe('Test personalization.js', () => {
           SPP: {
             status: 'MEMBER',
             firstName: 'Test Name',
-            level: 'Gold',
             company: 'Test Company',
-            primaryContact: true,
-            salesCenterAccess: true,
           },
+          level: 'Gold',
+          primaryContact: true,
+          salesCenterAccess: true,
         };
         document.cookie = `partner_data=${JSON.stringify(cookieObject)}`;
         const salesCenterLink = gnav.querySelector('#manage-profile-link');
@@ -346,8 +304,8 @@ describe('Test personalization.js', () => {
           SPP: {
             status: 'MEMBER',
             firstName: 'Test user',
-            level: 'Silver',
           },
+          level: 'Silver',
         };
         document.cookie = `partner_data=${JSON.stringify(cookieObject)}`;
         const { applyGnavPersonalization } = importModules();
@@ -375,9 +333,9 @@ describe('Test personalization.js', () => {
           SPP: {
             status: 'MEMBER',
             firstName: 'Test user',
-            level: 'Silver',
-            salesCenterAccess: false,
           },
+          level: 'Silver',
+          salesCenterAccess: false,
         };
         document.cookie = `partner_data=${JSON.stringify(cookieObject)}`;
         const { applyGnavPersonalization } = importModules();


### PR DESCRIPTION
Ticket: https://jira.corp.adobe.com/browse/MWPW-174955

Test url: https://mwpw-174955-remove-spp-tpp--da-dx-partners--adobecom.aem.page/digitalexperience/

SPP and TPP - /solutionpartners/ and /technologypartners/ are removed from codebase, not CPP or /channelpartners/ or /channelpartnerassets/

***IMPORTANT NOTE***

isRenew() functionality is removed from codebase as discussed with Abdel, since this functionality is not used on SPP/TPP portals, only APC

renewBanner is also removed for the same reason