### PR TITLE
MWPW-176043: remove COOKIE_OBJECT/getPartnerDataCookieObject

### DIFF
--- a/eds/scripts/personalizationConfigDX.js
+++ b/eds/scripts/personalizationConfigDX.js
@@ -1,4 +1,4 @@
-import { processPrimaryContact, processSalesAccess, COOKIE_OBJECT } from './personalizationUtils.js';
+import { processPrimaryContact, processSalesAccess } from './personalizationUtils.js';
 import {
   hasSalesCenterAccess,
   isAdminUser,
@@ -9,8 +9,9 @@ import {
   isSPPOnly,
   isTPPOnly,
   isSPPandTPP,
+  getPartnerDataCookieValue
 } from './utils.js';
-import { PARTNER_LEVEL, PROGRAM } from '../blocks/utils/dxConstants.js';
+import { PARTNER_LEVEL } from '../blocks/utils/dxConstants.js';
 
 export const PERSONALIZATION_PLACEHOLDERS = {
   'spp-firstName': '//*[contains(text(), "$spp-firstName")]',
@@ -37,7 +38,7 @@ export const PERSONALIZATION_CONDITIONS = {
   'partner-tpp-member': isTPPOnly(),
   'partner-spp-tpp-member': isSPPandTPP(),
   'partner-admin': isAdminUser(),
-  'partner-primary': COOKIE_OBJECT.primaryContact,
+  'partner-primary': getPartnerDataCookieValue('primarycontact'),
   'partner-newly-registered': isPartnerNewlyRegistered(),
 };
 

--- a/eds/scripts/personalizationUtils.js
+++ b/eds/scripts/personalizationUtils.js
@@ -1,8 +1,6 @@
-import { getPartnerDataCookieObject, getPartnerDataCookieValue, hasSalesCenterAccess } from './utils.js';
-import { PROGRAM } from '../blocks/utils/dxConstants.js';
+import { getPartnerDataCookieValue, hasSalesCenterAccess } from './utils.js';
 
 export const PERSONALIZATION_HIDE = 'personalization-hide';
-export const COOKIE_OBJECT = getPartnerDataCookieObject(PROGRAM);
 
 export function processPrimaryContact(el) {
   const isPrimary = getPartnerDataCookieValue('primarycontact');


### PR DESCRIPTION
Ticket: https://jira.corp.adobe.com/browse/MWPW-176043

Test url: https://mwpw-176043-primary-tag--da-dx-partners--adobecom.aem.page/digitalexperience/drafts/illya/primary-tag/page-with-gnav

Removed COOKIE_OBJECT/getPartnerDataCookieObject function and change to getPartnerDataCookieValue for primaryContact