### PR TITLE
update smoke tests to run on production, updated URLs and relative paths

### DIFF
--- a/nala/blocks/smoke-test/smoke.page.js
+++ b/nala/blocks/smoke-test/smoke.page.js
@@ -11,7 +11,7 @@ export default class SmokeTest {
     this.contactUsLinkAR = page.locator('a[href*="/en/apc-helpdesk"]');
     this.findPartnerLinkAR = page.locator('a[href*="/PartnerSearch?lang=en"]');
     this.learnMoreLinkAR = page.locator('a[href*="/na/channelpartners/program/"]');
-    this.visitAdobeExchangeLink = page.locator('a[href*="https://stage.exchange.adobe.com/"]');
+    this.visitAdobeExchangeLink = page.locator('a[href*="exchange.adobe.com/"]');
     this.joinNowLinkSP = page.locator('a[href*="/solution-partners/registration.html"]');
     this.joinNowLinkTP = page.locator('a[href*="/technologyprogram/experiencecloud/registration.html"]');
     this.joinNowLinkAR = page.locator('a[href*="/na/channelpartners/enrollment/"]');

--- a/nala/blocks/smoke-test/smoke.spec.js
+++ b/nala/blocks/smoke-test/smoke.spec.js
@@ -14,17 +14,17 @@ export default {
       testId: '@MWPW-168683',
       tags: '@da-dx-smoke-test',
       data: {
-        contactUsSPURL: 'https://solutionpartners.stage2.adobe.com/solution-partners/contact.html',
+        contactUsSPURL: '/solution-partners/contact.html',
         findPartnerSPURL: '/s/directory/solution',
-        learnMoreSPURL: 'https://solutionpartners.stage2.adobe.com/solution-partners/about.html',
+        learnMoreSPURL: '/solution-partners/about.html',
         contactUsTPURL: '/technologyprogram/experiencecloud/support.html',
         findPartnerTPURL: '/s/directory/technology',
         learnMoreTPURL: '/technologyprogram/experiencecloud/about.html',
-        contactUsARURL: 'https://cbconnection-stage.adobe.com/en/apc-helpdesk',
-        findPartnerARURL: 'https://adobe.my.salesforce-sites.com/PartnerSearch?lang=en',
+        contactUsARURL: '/en/apc-helpdesk',
+        findPartnerARURL: '/PartnerSearch?lang=en',
         learnMoreARURL: '/na/channelpartners/program/',
-        visitAdobeExchangeURL: 'https://stage.exchange.adobe.com/',
-      }
+        visitAdobeExchangeURL: 'exchange.adobe.com/',
+      },
     },
     {
       tcid: '3',
@@ -33,13 +33,13 @@ export default {
       path: '/join',
       tags: '@da-dx-smoke-test',
       data: {
-        learnMoreSPURL: 'https://solutionpartners.stage2.adobe.com/solution-partners/about.html',
-        joinNowSPURL: 'https://solutionpartners.stage2.adobe.com/solution-partners/registration.html',
+        learnMoreSPURL: '/solution-partners/about.html',
+        joinNowSPURL: '/solution-partners/registration.html',
         learnMoreTPURL: '/technologyprogram/experiencecloud/about.html',
         joinNowTPURL: '/technologyprogram/experiencecloud/registration.html',
         learnMoreARURL: '/na/channelpartners/program/',
         joinNowARURL: '/na/channelpartners/enrollment/',
-      }
+      },
     },
   ],
 };

--- a/nala/utils/nala.run.js
+++ b/nala/utils/nala.run.js
@@ -99,6 +99,8 @@ function getLocalTestLiveUrl(env, milolibs) {
       return 'http://127.0.0.1:6456';
     } else if (env === 'partners.stage') {
       return 'https://partners.stage.adobe.com';
+    } else if (env === 'partners') {
+      return 'https://partners.adobe.com';
     } else {
       return `https://${env}--da-dx-partners--adobecom.aem.live`;
     }


### PR DESCRIPTION
Test Url: https://mwpw-176961-prod-tests-run-setup--da-dx-partners--adobecom.aem.page/digitalexperience/
Updated mapp smoke tests to run on production 