### PR TITLE
update signin test to correct URL paths for spp-gold page regression

### DIFF
--- a/nala/blocks/signin/signin.spec.js
+++ b/nala/blocks/signin/signin.spec.js
@@ -15,11 +15,11 @@ export default {
     {
       tcid: '2',
       name: '@login-redirection-to-spp-gold-page',
-      path: 'https://partners.stage.adobe.com/digitalexperience/drafts/automation/regression/gold-page',
+      path: 'https://partners.stage.adobe.com/digitalexperience/drafts/automation/regression/gold/gold-page',
       tags: '@da-dx-signin @regression @circleCi',
       data: {
         partnerLevel: 'spp-gold:',
-        expectedToSeeInURL: '/digitalexperience/drafts/automation/regression/gold-page',
+        expectedToSeeInURL: '/digitalexperience/drafts/automation/regression/gold/gold-page',
       },
     },
     {


### PR DESCRIPTION
Test url: https://gold-page-update--da-dx-partners--adobecom.aem.live/digitalexperience/