### PR TITLE
mwpw-189394-prevent-modal-close

### DIFF
--- a/eds/scripts/certificationExpiresPopup.js
+++ b/eds/scripts/certificationExpiresPopup.js
@@ -2,6 +2,7 @@ import {
   getCurrentProgramType,
   getMetadataContent,
   invokeAfterImsIsReady,
+  preventModalClose,
   NEXT_POPUP_PLACEHOLDER,
   SHOW_NEXT_POPUP,
 } from './utils.js';
@@ -176,6 +177,7 @@ async function showPopup(miloLibs, portalMessagingOpen, partnerAgreementDisplaye
     );
     return false;
   }
+  preventModalClose(modal);
   const { loadArea } = await import(`${miloLibs}/utils/utils.js`);
   await loadArea(modal);
   personalizePlaceholders(PERSONALIZATION_PLACEHOLDERS, modal, getCurrentProgramType());

--- a/eds/scripts/partnerAgreement.js
+++ b/eds/scripts/partnerAgreement.js
@@ -3,7 +3,10 @@ import {
   getCookieValue,
   getCurrentProgramType,
   getMetadataContent,
-  getPartnerCookieValue, PORTAL_MESSAGING_POPUP, PARTNER_LOGIN_QUERY, SHOW_NEXT_POPUP,
+  getPartnerCookieValue,
+  preventModalClose,
+  PORTAL_MESSAGING_POPUP,
+  SHOW_NEXT_POPUP,
 } from "./utils.js";
 
 const RT_PARTNER_AGREEMENT_PATH = '/api/v1/web/dx-partners-runtime/partner-agreement';
@@ -137,29 +140,12 @@ async function handleAgreement(action) {
     }
 }
 
-function preventModalClose(modal) {
+function preventAgreementModalClose(modal) {
     // remove Milo close button
     const closeCta = modal.querySelector('#partner-agreement-modal .dialog-close');
     closeCta.remove();
 
-    // block Milo Escape keydown listener
-    const blockEscapeKey = function (e) {
-        if (e.key === 'Escape') {
-            e.preventDefault();
-            e.stopImmediatePropagation();
-        }
-    }
-    modal.addEventListener('keydown', blockEscapeKey, {capture: true});
-
-    // prevent closing the modal by clicking outside
-    const curtain = document.querySelector('.modal-curtain, .is-open');
-    const blockClickOutside = (e) => {
-        if (e.target === curtain) {
-            e.preventDefault();
-            e.stopImmediatePropagation();
-        }
-    };
-    curtain.addEventListener('click', blockClickOutside, {capture: true});
+    preventModalClose(modal);
 }
 
 async function loadAgreementMeta(metadataUrl) {
@@ -222,6 +208,6 @@ export async function partnerAgreement(miloLibs) {
         null,
         {class: 'commerce-frame', id: 'partner-agreement-modal', content, closeEvent: 'close-partner-agreement-modal'},
     );
-    preventModalClose(agreementModal);
+    preventAgreementModalClose(agreementModal);
     return true;
 }

--- a/eds/scripts/partnerAgreement.js
+++ b/eds/scripts/partnerAgreement.js
@@ -145,6 +145,15 @@ function preventAgreementModalClose(modal) {
     const closeCta = modal.querySelector('#partner-agreement-modal .dialog-close');
     closeCta.remove();
 
+    // block Milo Escape keydown listener
+    const blockEscapeKey = function (e) {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        e.stopImmediatePropagation();
+      }
+    }
+    modal.addEventListener('keydown', blockEscapeKey, {capture: true});
+
     preventModalClose(modal);
 }
 

--- a/eds/scripts/portalMessaging.js
+++ b/eds/scripts/portalMessaging.js
@@ -2,6 +2,7 @@ import {
   getCurrentProgramType,
   getMetadataContent,
   getPartnerCookieValue,
+  preventModalClose,
   CERTIFICATION_POPUP,
   SHOW_NEXT_POPUP,
 } from './utils.js';
@@ -99,6 +100,7 @@ export async function portalMessaging(miloLibs, partnerAgreementDisplayed) {
     );
     return false;
   }
+  preventModalClose(modal);
   const { loadArea } = await import(`${miloLibs}/utils/utils.js`);
   await loadArea(modal);
   personalizePlaceholders(PERSONALIZATION_PLACEHOLDERS, modal, getCurrentProgramType());

--- a/eds/scripts/utils.js
+++ b/eds/scripts/utils.js
@@ -575,3 +575,24 @@ export function loadPageToAnchor() {
     }
   }
 }
+
+export function preventModalClose(modal) {
+  // block Milo Escape keydown listener
+  const blockEscapeKey = function (e) {
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      e.stopImmediatePropagation();
+    }
+  }
+  modal.addEventListener('keydown', blockEscapeKey, {capture: true});
+
+  // prevent closing the modal by clicking outside
+  const curtain = document.querySelector('.modal-curtain, .is-open');
+  const blockClickOutside = (e) => {
+    if (e.target === curtain) {
+      e.preventDefault();
+      e.stopImmediatePropagation();
+    }
+  };
+  curtain.addEventListener('click', blockClickOutside, {capture: true});
+}

--- a/eds/scripts/utils.js
+++ b/eds/scripts/utils.js
@@ -577,15 +577,6 @@ export function loadPageToAnchor() {
 }
 
 export function preventModalClose(modal) {
-  // block Milo Escape keydown listener
-  const blockEscapeKey = function (e) {
-    if (e.key === 'Escape') {
-      e.preventDefault();
-      e.stopImmediatePropagation();
-    }
-  }
-  modal.addEventListener('keydown', blockEscapeKey, {capture: true});
-
   // prevent closing the modal by clicking outside
   const curtain = document.querySelector('.modal-curtain, .is-open');
   const blockClickOutside = (e) => {

--- a/test/scripts/certificationExpiresPopup.jest.js
+++ b/test/scripts/certificationExpiresPopup.jest.js
@@ -16,6 +16,7 @@ jest.mock('../../eds/scripts/utils.js', () => ({
   getMetadataContent: jest.fn(),
   isMember: jest.fn(),
   invokeAfterImsIsReady: jest.fn(async (callback) => await callback()), // Immediately invoke callback and await result
+  preventModalClose: jest.fn(),
 }));
 
 jest.mock('../../eds/scripts/portalMessaging.js', () => ({ loadPopupFragment: jest.fn() }));

--- a/test/scripts/partnerAgreement.jest.js
+++ b/test/scripts/partnerAgreement.jest.js
@@ -37,6 +37,7 @@ jest.mock('../../eds/scripts/utils.js', () => ({
   SHOW_NEXT_POPUP: 'dxp:showNextPopup',
   PORTAL_MESSAGING_POPUP: 'dxp:portalMessaging',
   CERTIFICATION_POPUP: 'dxp:certificationExpires',
+  preventModalClose: jest.fn(),
 }));
 
 // Global fetch mock

--- a/test/scripts/portalMessaging.jest.js
+++ b/test/scripts/portalMessaging.jest.js
@@ -40,6 +40,7 @@ jest.mock('../../eds/scripts/utils.js', () => ({
   PORTAL_MESSAGING_POPUP: 'dxp:portalMessaging',
   CERTIFICATION_POPUP: 'dxp:certificationExpires',
   SHOW_NEXT_POPUP: 'dxp:showNextPopup',
+  preventModalClose: jest.fn(),
 }));
 
 global.fetch = jest.fn();


### PR DESCRIPTION
Test URL: https://mwpw-189394-modal-close--da-dx-partners--adobecom.aem.live/digitalexperience/

Note: With these fix, we should verify that the following three modals close as expected: partnerAgreement, certificationExpires and portalMessaging.