### PR TITLE
MWPW-190102 - double event fired on spectrum btn

### DIFF
--- a/eds/blocks/search-full/search-full.js
+++ b/eds/blocks/search-full/search-full.js
@@ -62,7 +62,6 @@ export default async function init(el) {
     import(`${miloLibs}/features/spectrum-web-components/dist/checkbox.js`),
     import(`${miloLibs}/features/spectrum-web-components/dist/button.js`),
     import(`${miloLibs}/features/spectrum-web-components/dist/progress-circle.js`),
-    import(`${miloLibs}/features/spectrum-web-components/dist/action-button.js`),
     import(`${miloLibs}/features/spectrum-web-components/dist/icons-workflow.js`),
     import(`${miloLibs}/features/spectrum-web-components/dist/button-group.js`),
   ]);

--- a/eds/components/SearchCard.css
+++ b/eds/components/SearchCard.css
@@ -51,9 +51,26 @@
   overflow-wrap: anywhere;
 }
 
-.card-header .card-icons {
+.search-card .card-header .card-icons {
   z-index: 1;
   flex-shrink: 0;
+}
+
+.search-card .card-header .card-icons .card-btn {
+  color: #222;
+  border: 1px solid #b1b1b1;
+  display: flex;
+  border-radius: 4px;
+  padding: 6px 11px;
+}
+
+.search-card .card-header .card-icons .card-btn:hover {
+  background: #e6e6e6;
+}
+
+.search-card .card-header .card-icons .card-btn .open-in-icon {
+  width: 18px;
+  height: 18px;
 }
 
 .search-card .card-content {

--- a/eds/components/SearchCard.css
+++ b/eds/components/SearchCard.css
@@ -68,7 +68,7 @@
   background: #e6e6e6;
 }
 
-.search-card .card-header .card-icons .card-btn .open-in-icon {
+.search-card .card-header .card-icons .card-btn sp-icon-open-in {
   width: 18px;
   height: 18px;
 }

--- a/eds/components/SearchCard.js
+++ b/eds/components/SearchCard.js
@@ -67,9 +67,7 @@ class SearchCard extends LitElement {
             <span class="card-title">${this.data.contentArea?.title !== 'card-metadata' ? this.data.contentArea?.title : ''}</span>
           </div>
           <div class="card-icons">
-              <a class="card-btn" @click=${(e) => this.onCardBtnClick(e)} href="${this.data.contentArea?.url}" target="_blank" aria-label="${this.localizedText['{{open-in}}']}" daa-ll="${processTrackingLabels(this.data.contentArea?.title !== 'card-metadata' ? this.data.contentArea?.title : '', getConfig(), 30)}">
-                <sp-icon-open-in class="open-in-icon" />
-              </a>
+              <a class="card-btn" @click=${(e) => this.onCardBtnClick(e)} href="${this.data.contentArea?.url}" target="_blank" aria-label="${this.localizedText['{{open-in}}']}" daa-ll="${processTrackingLabels(this.data.contentArea?.title !== 'card-metadata' ? this.data.contentArea?.title : '', getConfig(), 30)}"><sp-icon-open-in /></a>
           </div>
         </div>
 

--- a/eds/components/SearchCard.js
+++ b/eds/components/SearchCard.js
@@ -53,10 +53,7 @@ class SearchCard extends LitElement {
   // eslint-disable-next-line class-methods-use-this
   onCardBtnClick(e) {
     e.stopPropagation();
-    if (e.isTrusted) {
-      e.preventDefault();
-      dispatchCustomEventOnLinkClick(e, e.target.getAttribute('href'), processTrackingLabels(e.target.getAttribute('daa-ll'), config, 30));
-    }
+    dispatchCustomEventOnLinkClick(e, e.target.getAttribute('href'), processTrackingLabels(e.target.getAttribute('daa-ll'), config, 30));
   }
 
   /* eslint-disable indent */
@@ -70,9 +67,9 @@ class SearchCard extends LitElement {
             <span class="card-title">${this.data.contentArea?.title !== 'card-metadata' ? this.data.contentArea?.title : ''}</span>
           </div>
           <div class="card-icons">
-            <sp-theme theme="spectrum" color="light" scale="medium">
-              <sp-action-button @click=${(e) => this.onCardBtnClick(e)} href="${this.data.contentArea?.url}" target="_blank" aria-label="${this.localizedText['{{open-in}}']}" daa-ll="${processTrackingLabels(this.data.contentArea?.title !== 'card-metadata' ? this.data.contentArea?.title : '', getConfig(), 30)}"><sp-icon-open-in /></sp-action-button>
-            </sp-theme>
+              <a class="card-btn" @click=${(e) => this.onCardBtnClick(e)} href="${this.data.contentArea?.url}" target="_blank" aria-label="${this.localizedText['{{open-in}}']}" daa-ll="${processTrackingLabels(this.data.contentArea?.title !== 'card-metadata' ? this.data.contentArea?.title : '', getConfig(), 30)}">
+                <sp-icon-open-in class="open-in-icon" />
+              </a>
           </div>
         </div>
 

--- a/test/blocks/search-full/search-full.test.js
+++ b/test/blocks/search-full/search-full.test.js
@@ -1709,7 +1709,7 @@ describe('SearchCard Unit Tests', () => {
       const firstCard = searchCardsWrapper.querySelector('search-card');
       expect(firstCard.getAttribute('daa-lh')).to.equal(`Search Card 1 | ${cards[0].contentArea.title}`);
 
-      const singlePartnerCardBtn = firstCard.querySelector('sp-action-button');
+      const singlePartnerCardBtn = firstCard.querySelector('.card-btn');
       expect(singlePartnerCardBtn.getAttribute('daa-ll')).to.equal(cards[0].contentArea.title);
     });
   });


### PR DESCRIPTION
Test URL: https://mwpw-190102-double-fired-e--da-dx-partners--adobecom.aem.page/digitalexperience/

Resolves: https://jira.corp.adobe.com/browse/MWPW-190102

NOTE: According to the Spectrum Action Button documentation, the `href` attribute and other link-related properties (`target`, `download`, `referrerpolicy`, `rel`) on `<sp-action-button>` are deprecated and will be removed in a future release.

According to the documentation: If we need to use the `href` attribute, we should use an `<a>` element instead. Using an `<a>` element resolves the current issue with double-fired events.

Documentation: https://opensource.adobe.com/spectrum-web-components/components/action-button/
