### PR TITLE
MWPW-197689-pdf-viewer re-enabled 'full-window' variant

### DIFF
--- a/eds/blocks/asset-preview/AssetPreview.js
+++ b/eds/blocks/asset-preview/AssetPreview.js
@@ -190,7 +190,7 @@ export default class AssetPreview extends LitElement {
     this.url = DOMPurify.sanitize(assetMetadata.url);
     this.webinarPresentation = DOMPurify.sanitize(assetMetadata.webinarPresentation);
     this.previewImage = DOMPurify.sanitize(assetMetadata.previewImage);
-    this.blockData.pdfEmbedMode = DOMPurify.sanitize(this.blockData.pdfEmbedMode) || 'sized-container';
+    this.blockData.pdfEmbedMode = DOMPurify.sanitize(this.blockData.pdfEmbedMode) || 'full-window';
     this.backButtonUrl = DOMPurify.sanitize(this.blockData.backButtonUrl);
     this.backButtonLabel = DOMPurify.sanitize(this.blockData.backButtonLabel || DEFAULT_BACK_BTN_LABEL);
     this.tags = assetMetadata.tags

--- a/eds/blocks/asset-preview/AssetPreview.js
+++ b/eds/blocks/asset-preview/AssetPreview.js
@@ -147,7 +147,7 @@ export default class AssetPreview extends LitElement {
       },
       'pdf-embed-mode': (cols) => {
         const [pdfEmbedModeEl] = cols;
-        this.blockData.pdfEmbedMode = pdfEmbedModeEl.innerText.trim().toLowerCase().replace(/ /g, '-');
+        this.blockData.pdfEmbedMode = pdfEmbedModeEl?.innerText.trim().toLowerCase().replace(/ /g, '-');
       },
     };
     const rows = Array.from(this.blockData.tableData);

--- a/eds/components/PdfViewer.js
+++ b/eds/components/PdfViewer.js
@@ -6,7 +6,7 @@ const { loadStyle } = await import(`${miloLibs}/utils/utils.js`);
 const API_SOURCE_URL = 'https://documentservices.adobe.com/view-sdk/viewer.js';
 
 const PDF_EMBED_MODE_CONFIG = {
-  // 'full-window': { embedMode: 'FULL_WINDOW', defaultViewMode: 'FIT_WIDTH' }, // TODO: Re-enable once the PDF viewer team's search bug is fixed
+  'full-window': { embedMode: 'FULL_WINDOW', defaultViewMode: 'FIT_WIDTH' },
   'sized-container': { embedMode: 'SIZED_CONTAINER' },
   'in-line': { embedMode: 'IN_LINE' },
 };
@@ -54,11 +54,11 @@ export const getPdfConfig = () => {
   return config.env?.consumer?.pdfViewerClientId || config.pdfViewerClientId;
 };
 
-const initPdfViewer = async ({ url, fileName, divId, pdfEmbedMode = 'sized-container' }) => {
+const initPdfViewer = async ({ url, fileName, divId, pdfEmbedMode = 'full-window' }) => {
   await loadStyle('/eds/components/PdfViewer.css');
   const clientId = getPdfConfig();
 
-  const embedMode = PDF_EMBED_MODE_CONFIG[pdfEmbedMode] ? pdfEmbedMode : 'sized-container';
+  const embedMode = PDF_EMBED_MODE_CONFIG[pdfEmbedMode] ? pdfEmbedMode : 'full-window';
   const pdfEmbedConfig = PDF_EMBED_MODE_CONFIG[embedMode];
 
   const initViewer = () => {

--- a/test/blocks/asset-preview/asset-preview.test.js
+++ b/test/blocks/asset-preview/asset-preview.test.js
@@ -130,19 +130,19 @@ describe('AssetPreview - setData() pdfPreviewUrl', () => {
     expect(el.pdfPreviewUrl).to.equal('https://example.com/rendition.pdf');
   });
 
-  it('defaults pdfEmbedMode to sized-container when not set', async () => {
+  it('defaults pdfEmbedMode to full-window when not set', async () => {
     const el = makeInstance();
     sinon.stub(el, 'loadPdfViewer');
     await el.setData({ title: 'Test', url: 'https://example.com/file.pdf', tags: [] });
-    expect(el.blockData.pdfEmbedMode).to.equal('sized-container');
+    expect(el.blockData.pdfEmbedMode).to.equal('full-window');
   });
 
   it('keeps existing pdfEmbedMode when already set in blockData', async () => {
     const el = makeInstance();
-    el.blockData.pdfEmbedMode = 'sized-container';
+    el.blockData.pdfEmbedMode = 'full-window';
     sinon.stub(el, 'loadPdfViewer');
     await el.setData({ title: 'Test', url: 'https://example.com/file.pdf', tags: [] });
-    expect(el.blockData.pdfEmbedMode).to.equal('sized-container');
+    expect(el.blockData.pdfEmbedMode).to.equal('full-window');
   });
 });
 

--- a/test/components/PdfViewer.test.js
+++ b/test/components/PdfViewer.test.js
@@ -2,8 +2,6 @@ import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
 import { setLibs, getLibs } from '../../eds/scripts/utils.js';
 
-// TODO: Re-enable the full-window test once the PDF viewer team's search bug is fixed
-
 setLibs('/libs');
 
 const miloLibs = getLibs();
@@ -102,14 +100,14 @@ describe('PdfViewer', () => {
     it('should default to FULL_WINDOW when pdfEmbedMode is omitted', async () => {
       await initPdfViewer({ url: TEST_URL, fileName: TEST_FILE_NAME, divId: TEST_DIV_ID });
 
-      expect(previewFileStub.firstCall.args[1].embedMode).to.equal('SIZED_CONTAINER');
+      expect(previewFileStub.firstCall.args[1].embedMode).to.equal('FULL_WINDOW');
     });
 
-    // it('should use FULL_WINDOW for "full-window"', async () => {
-    //   await initPdfViewer({ url: TEST_URL, fileName: TEST_FILE_NAME, divId: TEST_DIV_ID, pdfEmbedMode: 'full-window' });
-    //
-    //   expect(previewFileStub.firstCall.args[1].embedMode).to.equal('FULL_WINDOW');
-    // });
+    it('should use FULL_WINDOW for "full-window"', async () => {
+      await initPdfViewer({ url: TEST_URL, fileName: TEST_FILE_NAME, divId: TEST_DIV_ID, pdfEmbedMode: 'full-window' });
+
+      expect(previewFileStub.firstCall.args[1].embedMode).to.equal('FULL_WINDOW');
+    });
 
     it('should use SIZED_CONTAINER for "sized-container"', async () => {
       await initPdfViewer({ url: TEST_URL, fileName: TEST_FILE_NAME, divId: TEST_DIV_ID, pdfEmbedMode: 'sized-container' });
@@ -126,29 +124,29 @@ describe('PdfViewer', () => {
     it('should fall back to FULL_WINDOW for an unrecognised mode', async () => {
       await initPdfViewer({ url: TEST_URL, fileName: TEST_FILE_NAME, divId: TEST_DIV_ID, pdfEmbedMode: 'unknown' });
 
-      expect(previewFileStub.firstCall.args[1].embedMode).to.equal('SIZED_CONTAINER');
+      expect(previewFileStub.firstCall.args[1].embedMode).to.equal('FULL_WINDOW');
     });
 
-    // it('should set defaultViewMode FIT_WIDTH for full-window', async () => {
-    //   await initPdfViewer({ url: TEST_URL, fileName: TEST_FILE_NAME, divId: TEST_DIV_ID, pdfEmbedMode: 'full-window' });
-    //
-    //   expect(previewFileStub.firstCall.args[1].defaultViewMode).to.equal('FIT_WIDTH');
-    // });
+    it('should set defaultViewMode FIT_WIDTH for full-window', async () => {
+      await initPdfViewer({ url: TEST_URL, fileName: TEST_FILE_NAME, divId: TEST_DIV_ID, pdfEmbedMode: 'full-window' });
+
+      expect(previewFileStub.firstCall.args[1].defaultViewMode).to.equal('FIT_WIDTH');
+    });
   });
 
   // -------------------------------------------------------------------------
   describe('initPdfViewer – container CSS classes', () => {
-    // it('should add the embed-mode string as a class to the container', async () => {
-    //   await initPdfViewer({ url: TEST_URL, fileName: TEST_FILE_NAME, divId: TEST_DIV_ID, pdfEmbedMode: 'full-window' });
-    //
-    //   expect(document.getElementById(TEST_DIV_ID).classList.contains('full-window')).to.be.true;
-    // });
-    //
-    // it('should add "landscape" for full-window', async () => {
-    //   await initPdfViewer({ url: TEST_URL, fileName: TEST_FILE_NAME, divId: TEST_DIV_ID, pdfEmbedMode: 'full-window' });
-    //
-    //   expect(document.getElementById(TEST_DIV_ID).classList.contains('landscape')).to.be.true;
-    // });
+    it('should add the embed-mode string as a class to the container', async () => {
+      await initPdfViewer({ url: TEST_URL, fileName: TEST_FILE_NAME, divId: TEST_DIV_ID, pdfEmbedMode: 'full-window' });
+
+      expect(document.getElementById(TEST_DIV_ID).classList.contains('full-window')).to.be.true;
+    });
+
+    it('should add "landscape" for full-window', async () => {
+      await initPdfViewer({ url: TEST_URL, fileName: TEST_FILE_NAME, divId: TEST_DIV_ID, pdfEmbedMode: 'full-window' });
+
+      expect(document.getElementById(TEST_DIV_ID).classList.contains('landscape')).to.be.true;
+    });
 
     it('should add "landscape" for sized-container', async () => {
       await initPdfViewer({ url: TEST_URL, fileName: TEST_FILE_NAME, divId: TEST_DIV_ID, pdfEmbedMode: 'sized-container' });


### PR DESCRIPTION
**TestURL:** https://mwpw-193917-pdf-viewer3--da-dx-partners--adobecom.aem.page/digitalexperience/

**NOTE:** Per Abdel's request, the `full-window` variant has been re-enabled and is set as the default for the next release.

The search box issue will be handled by the PDF Viewer team: https://jira.corp.adobe.com/browse/ADCS-76611
However, per Abdel's request, this should not block us from enabling the variant.