### PR TITLE
MWPW-201519

### DIFF
--- a/eds/blocks/calendly/calendly.css
+++ b/eds/blocks/calendly/calendly.css
@@ -1,49 +1,10 @@
 .calendly {
   width: 100%;
-}
-
-.calendly .foreground {
-  max-width: var(--grid-container-width);
-  margin: 0 auto;
-  padding: 0 var(--spacing-m);
-  box-sizing: border-box;
-}
-
-[class*=-up] .calendly .foreground {
-  max-width: none;
+  padding-top: 24px;
 }
 
 .calendly .calendly-embed {
   width: 100%;
   min-width: 320px;
   min-height: 700px;
-}
-
-.calendly .calendly-booked-message {
-  margin: var(--spacing-m) 0;
-  padding: var(--spacing-m);
-  border: 1px solid var(--color-gray-200, #d5d5d5);
-  border-radius: 8px;
-  background-color: var(--color-gray-50, #f8f8f8);
-  color: var(--color-gray-900, #2c2c2c);
-  font-size: 16px;
-  line-height: 1.5;
-}
-
-@media (max-width: 599px) {
-  .calendly .foreground {
-    padding: 0 var(--spacing-s);
-  }
-
-  .calendly .calendly-booked-message {
-    margin: var(--spacing-s) 0;
-    padding: var(--spacing-s);
-    font-size: 14px;
-  }
-}
-
-@media (min-width: 600px) and (max-width: 1199px) {
-  .calendly .foreground {
-    padding: 0 var(--spacing-m);
-  }
 }

--- a/eds/blocks/calendly/calendly.css
+++ b/eds/blocks/calendly/calendly.css
@@ -1,10 +1,49 @@
 .calendly {
   width: 100%;
-  padding-top: 24px;
+}
+
+.calendly .foreground {
+  max-width: var(--grid-container-width);
+  margin: 0 auto;
+  padding: 0 var(--spacing-m);
+  box-sizing: border-box;
+}
+
+[class*=-up] .calendly .foreground {
+  max-width: none;
 }
 
 .calendly .calendly-embed {
   width: 100%;
   min-width: 320px;
   min-height: 700px;
+}
+
+.calendly .calendly-booked-message {
+  margin: var(--spacing-m) 0;
+  padding: var(--spacing-m);
+  border: 1px solid var(--color-gray-200, #d5d5d5);
+  border-radius: 8px;
+  background-color: var(--color-gray-50, #f8f8f8);
+  color: var(--color-gray-900, #2c2c2c);
+  font-size: 16px;
+  line-height: 1.5;
+}
+
+@media (max-width: 599px) {
+  .calendly .foreground {
+    padding: 0 var(--spacing-s);
+  }
+
+  .calendly .calendly-booked-message {
+    margin: var(--spacing-s) 0;
+    padding: var(--spacing-s);
+    font-size: 14px;
+  }
+}
+
+@media (min-width: 600px) and (max-width: 1199px) {
+  .calendly .foreground {
+    padding: 0 var(--spacing-m);
+  }
 }

--- a/eds/blocks/calendly/calendly.js
+++ b/eds/blocks/calendly/calendly.js
@@ -18,7 +18,7 @@ let toastStyleLoaded = false;
 
 const CALENDLY_ERROR_TOAST = { toastNegative: 'Unable to save your booking. Please contact support if the issue persists.' };
 
-const CALENDLY_DOUBLE_BOOKING_TOAST = { toastNegative: CALENDLY_ALREADY_BOOKED_MESSAGE };
+const CALENDLY_DOUBLE_BOOKING_TOAST = { toastNegative: 'Calendly event was already booked by another admin.' };
 
 const delay = (ms) => new Promise((resolve) => {
   setTimeout(resolve, ms);

--- a/eds/blocks/calendly/calendly.js
+++ b/eds/blocks/calendly/calendly.js
@@ -1,5 +1,5 @@
 import showToast from '../../components/Toast.js';
-import { updatePartnerAccountState } from '../../scripts/partnerStateUtils.js';
+import { refreshPartnerAccountState, updatePartnerAccountState } from '../../scripts/partnerStateUtils.js';
 import {
   getCurrentProgramType,
   getLibs,
@@ -17,7 +17,9 @@ let toastStyleLoaded = false;
 
 const CALENDLY_ERROR_TOAST = { toastNegative: 'Unable to save your booking. Please contact support if the issue persists.' };
 
-const CALENDLY_DOUBLE_BOOKING_TOAST = { toastNegative: 'A session is already scheduled for your account. Our team will reach out to help coordinate your bookings.' };
+const CALENDLY_ALREADY_BOOKED_MESSAGE = 'Calendly already booked by another admin.';
+
+const CALENDLY_DOUBLE_BOOKING_TOAST = { toastNegative: CALENDLY_ALREADY_BOOKED_MESSAGE };
 
 const delay = (ms) => new Promise((resolve) => {
   setTimeout(resolve, ms);
@@ -33,6 +35,20 @@ function getCalendlyEventId(eventUri) {
 
 function hasCalendlyBooked() {
   return !!getPartnerAccountState()?.calendly;
+}
+
+function showCalendlyBookedMessage(container) {
+  container.classList.add('con-block');
+
+  const foreground = document.createElement('div');
+  foreground.className = 'foreground';
+
+  const message = document.createElement('div');
+  message.className = 'calendly-booked-message';
+  message.textContent = CALENDLY_ALREADY_BOOKED_MESSAGE;
+
+  foreground.append(message);
+  container.append(foreground);
 }
 
 function loadCalendlyScript() {
@@ -168,13 +184,27 @@ function setBlockData(tableRows) {
 }
 export default async function init(el) {
   const { schedulingLink, companyQuestionKey } = setBlockData(el.children);
-  const calendlyEmbed = document.createElement('div');
-  calendlyEmbed.className = 'calendly-embed';
-
-  el.innerHTML = '';
-  el.append(calendlyEmbed);
 
   try {
+    await loadStyle('/eds/blocks/calendly/calendly.css');
+    await refreshPartnerAccountState();
+
+    el.innerHTML = '';
+
+    if (hasCalendlyBooked()) {
+      showCalendlyBookedMessage(el);
+      return;
+    }
+
+    const calendlyEmbed = document.createElement('div');
+    calendlyEmbed.className = 'calendly-embed';
+
+    el.classList.add('con-block');
+    const foreground = document.createElement('div');
+    foreground.className = 'foreground';
+    foreground.append(calendlyEmbed);
+    el.append(foreground);
+
     await loadCalendlyScript();
     initCalendly(schedulingLink, calendlyEmbed, companyQuestionKey);
     window.addEventListener('message', trackCalendlyEvent);

--- a/eds/blocks/calendly/calendly.js
+++ b/eds/blocks/calendly/calendly.js
@@ -18,7 +18,7 @@ let toastStyleLoaded = false;
 
 const CALENDLY_ERROR_TOAST = { toastNegative: 'Unable to save your booking. Please contact support if the issue persists.' };
 
-const CALENDLY_DOUBLE_BOOKING_TOAST = { toastNegative: 'Calendly event was already booked by another admin.' };
+const CALENDLY_DOUBLE_BOOKING_TOAST = { toastNegative: 'A session is already scheduled for your account. Our team will reach out to help coordinate your bookings.' };
 
 const delay = (ms) => new Promise((resolve) => {
   setTimeout(resolve, ms);

--- a/eds/blocks/calendly/calendly.js
+++ b/eds/blocks/calendly/calendly.js
@@ -6,6 +6,7 @@ import {
   getPartnerAccountState,
   getPartnerCookieObject,
 } from '../../scripts/utils.js';
+import { keepInlineFragmentInDOM } from '../utils/utils.js';
 
 const miloLibs = getLibs();
 const { loadStyle } = await import(`${miloLibs}/utils/utils.js`);
@@ -16,8 +17,6 @@ let calendlyScriptPromise;
 let toastStyleLoaded = false;
 
 const CALENDLY_ERROR_TOAST = { toastNegative: 'Unable to save your booking. Please contact support if the issue persists.' };
-
-const CALENDLY_ALREADY_BOOKED_MESSAGE = 'Calendly already booked by another admin.';
 
 const CALENDLY_DOUBLE_BOOKING_TOAST = { toastNegative: CALENDLY_ALREADY_BOOKED_MESSAGE };
 
@@ -35,20 +34,6 @@ function getCalendlyEventId(eventUri) {
 
 function hasCalendlyBooked() {
   return !!getPartnerAccountState()?.calendly;
-}
-
-function showCalendlyBookedMessage(container) {
-  container.classList.add('con-block');
-
-  const foreground = document.createElement('div');
-  foreground.className = 'foreground';
-
-  const message = document.createElement('div');
-  message.className = 'calendly-booked-message';
-  message.textContent = CALENDLY_ALREADY_BOOKED_MESSAGE;
-
-  foreground.append(message);
-  container.append(foreground);
 }
 
 function loadCalendlyScript() {
@@ -184,27 +169,24 @@ function setBlockData(tableRows) {
 }
 export default async function init(el) {
   const { schedulingLink, companyQuestionKey } = setBlockData(el.children);
-
   try {
-    await loadStyle('/eds/blocks/calendly/calendly.css');
     await refreshPartnerAccountState();
-
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.log('err', error);
+  }
+  const calendlyEmbed = document.createElement('div');
+  if (hasCalendlyBooked()) {
+    keepInlineFragmentInDOM(Array.from(el.children), calendlyEmbed, 'already-booked-fragment', false);
     el.innerHTML = '';
+    el.append(calendlyEmbed);
+    return;
+  }
 
-    if (hasCalendlyBooked()) {
-      showCalendlyBookedMessage(el);
-      return;
-    }
-
-    const calendlyEmbed = document.createElement('div');
-    calendlyEmbed.className = 'calendly-embed';
-
-    el.classList.add('con-block');
-    const foreground = document.createElement('div');
-    foreground.className = 'foreground';
-    foreground.append(calendlyEmbed);
-    el.append(foreground);
-
+  calendlyEmbed.className = 'calendly-embed';
+  el.innerHTML = '';
+  el.append(calendlyEmbed);
+  try {
     await loadCalendlyScript();
     initCalendly(schedulingLink, calendlyEmbed, companyQuestionKey);
     window.addEventListener('message', trackCalendlyEvent);

--- a/eds/blocks/utils/utils.js
+++ b/eds/blocks/utils/utils.js
@@ -129,7 +129,7 @@ export function isProd() {
   return prodHosts.includes(window.location.host);
 }
 
-export function keepInlineFragmentInDOM(tableRows, blockElement, fragmentRowTitle) {
+export function keepInlineFragmentInDOM(tableRows, blockElement, fragmentRowTitle, hide = true) {
   tableRows.forEach((row) => {
     const cols = Array.from(row.children);
     const rowTitle = cols[0].innerText.trim().toLowerCase().replace(/ /g, '-');
@@ -138,7 +138,7 @@ export function keepInlineFragmentInDOM(tableRows, blockElement, fragmentRowTitl
       const inlineXfContent = document.createElement('div');
       inlineXfContent.append(...colsContent[0].childNodes);
 
-      inlineXfContent.style.display = 'none';
+      inlineXfContent.style.display = hide ? 'none' : 'block';
       inlineXfContent.id = fragmentRowTitle;
       blockElement.appendChild(inlineXfContent);
     }

--- a/eds/scripts/partnerStateUtils.js
+++ b/eds/scripts/partnerStateUtils.js
@@ -14,19 +14,29 @@ function getErrorText(body) {
   return '';
 }
 
-async function updatePartnerState(action, stateUpdates) {
+function buildStateManagementBody(action, stateUpdates) {
+  const body = {
+    hostUrl: window.location.origin,
+    programType: getCurrentProgramType().toUpperCase(),
+    action,
+  };
+
+  if (stateUpdates) {
+    body.email = getPartnerCookieValue('email');
+    body.stateUpdates = stateUpdates;
+  }
+
+  return body;
+}
+
+async function callStateManagement(action, stateUpdates) {
   try {
     const url = getRuntimeActionUrl(RT_DXP_STATE_MANAGEMENT_PATH);
     const response = await fetch(url, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       credentials: 'include',
-      body: JSON.stringify({
-        programType: getCurrentProgramType().toUpperCase(),
-        action,
-        email: getPartnerCookieValue('email'),
-        stateUpdates,
-      }),
+      body: JSON.stringify(buildStateManagementBody(action, stateUpdates)),
     });
 
     const body = await response.json().catch(() => null);
@@ -49,9 +59,13 @@ async function updatePartnerState(action, stateUpdates) {
 }
 
 export function updatePartnerUserState(stateUpdates) {
-  return updatePartnerState('updatePartnerUserState', stateUpdates);
+  return callStateManagement('updatePartnerUserState', stateUpdates);
 }
 
 export function updatePartnerAccountState(stateUpdates) {
-  return updatePartnerState('updatePartnerAccountState', stateUpdates);
+  return callStateManagement('updatePartnerAccountState', stateUpdates);
+}
+
+export function refreshPartnerAccountState() {
+  return callStateManagement('refreshPartnerAccountState');
 }

--- a/eds/scripts/partnerStateUtils.js
+++ b/eds/scripts/partnerStateUtils.js
@@ -16,13 +16,12 @@ function getErrorText(body) {
 
 function buildStateManagementBody(action, stateUpdates) {
   const body = {
-    hostUrl: window.location.origin,
     programType: getCurrentProgramType().toUpperCase(),
     action,
+    email: getPartnerCookieValue('email'),
   };
 
   if (stateUpdates) {
-    body.email = getPartnerCookieValue('email');
     body.stateUpdates = stateUpdates;
   }
 

--- a/test/scripts/partnerStateUtils.jest.js
+++ b/test/scripts/partnerStateUtils.jest.js
@@ -3,6 +3,7 @@
  */
 
 import {
+  refreshPartnerAccountState,
   updatePartnerAccountState,
   updatePartnerUserState,
 } from '../../eds/scripts/partnerStateUtils.js';
@@ -34,6 +35,7 @@ describe('partnerStateUtils', () => {
         method: 'POST',
         credentials: 'include',
         body: JSON.stringify({
+          hostUrl: 'http://localhost',
           programType: 'DXP',
           action: 'updatePartnerUserState',
           email: 'test@adobetest.com',
@@ -57,6 +59,7 @@ describe('partnerStateUtils', () => {
       'https://runtime.com/api/v1/web/dx-partners-runtime/dxp-state-management',
       expect.objectContaining({
         body: JSON.stringify({
+          hostUrl: 'http://localhost',
           programType: 'DXP',
           action: 'updatePartnerAccountState',
           email: 'test@adobetest.com',
@@ -97,5 +100,27 @@ describe('partnerStateUtils', () => {
       status: 409,
       errorText: 'dxpAccountState is not fresh',
     });
+  });
+
+  it('refreshes partner account state cookie via runtime action', async () => {
+    global.fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ message: 'ok' }),
+    });
+
+    const result = await refreshPartnerAccountState();
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://runtime.com/api/v1/web/dx-partners-runtime/dxp-state-management',
+      expect.objectContaining({
+        body: JSON.stringify({
+          hostUrl: 'http://localhost',
+          programType: 'DXP',
+          action: 'refreshPartnerAccountState',
+        }),
+      }),
+    );
+    expect(result.success).toBe(true);
   });
 });

--- a/test/scripts/partnerStateUtils.jest.js
+++ b/test/scripts/partnerStateUtils.jest.js
@@ -35,7 +35,6 @@ describe('partnerStateUtils', () => {
         method: 'POST',
         credentials: 'include',
         body: JSON.stringify({
-          hostUrl: 'http://localhost',
           programType: 'DXP',
           action: 'updatePartnerUserState',
           email: 'test@adobetest.com',
@@ -59,7 +58,6 @@ describe('partnerStateUtils', () => {
       'https://runtime.com/api/v1/web/dx-partners-runtime/dxp-state-management',
       expect.objectContaining({
         body: JSON.stringify({
-          hostUrl: 'http://localhost',
           programType: 'DXP',
           action: 'updatePartnerAccountState',
           email: 'test@adobetest.com',
@@ -115,9 +113,9 @@ describe('partnerStateUtils', () => {
       'https://runtime.com/api/v1/web/dx-partners-runtime/dxp-state-management',
       expect.objectContaining({
         body: JSON.stringify({
-          hostUrl: 'http://localhost',
           programType: 'DXP',
           action: 'refreshPartnerAccountState',
+          email: 'test@adobetest.com',
         }),
       }),
     );


### PR DESCRIPTION
Test URL: https://mwpw-195867-calendly-block-impr--da-dx-partners--adobecom.aem.live/digitalexperience/

refreshing partner account state cookie on component load and based on that display calendly or fragment that would contain message that calendly is already booked
related ticket https://jira.corp.adobe.com/browse/MWPW-201519 